### PR TITLE
Remove DiscordSRV and use our own implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.github.atomishere'
-version '3.0-SNAPSHOT'
+version '3.0.1-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'net.hypixel:HypixelAPI:3.1.0'
 
     implementation 'com.jagrosh:jda-utilities:3.0.5'
-    compileOnly 'com.discordsrv:discordsrv:1.20.0'
+    implementation 'net.dv8tion:JDA:4.2.0_222'
 
     compileOnly 'org.projectlombok:lombok:1.18.16'
     annotationProcessor 'org.projectlombok:lombok:1.18.16'

--- a/src/main/java/com/github/atomishere/skybanebot/SkybaneBot.java
+++ b/src/main/java/com/github/atomishere/skybanebot/SkybaneBot.java
@@ -25,7 +25,6 @@ import com.github.atomishere.skybanebot.discord.DiscordManager;
 import com.github.atomishere.skybanebot.inactivity.InactivityManager;
 import com.github.atomishere.skybanebot.service.ServiceManager;
 import lombok.Getter;
-import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class SkybaneBot extends JavaPlugin {
@@ -43,6 +42,8 @@ public class SkybaneBot extends JavaPlugin {
 
     @Getter
     private InactivityManager inactivityManager;
+    @Getter
+    private DiscordManager discordManager;
 
     @Override
     public void onEnable() {
@@ -59,7 +60,7 @@ public class SkybaneBot extends JavaPlugin {
         serviceManager.registerService(WhitelistManager.class);
 
         inactivityManager = serviceManager.registerService(InactivityManager.class);
-        serviceManager.registerService(DiscordManager.class);
+        discordManager = serviceManager.registerService(DiscordManager.class);
 
         //
         serviceManager.startServices();

--- a/src/main/java/com/github/atomishere/skybanebot/SkybaneBot.java
+++ b/src/main/java/com/github/atomishere/skybanebot/SkybaneBot.java
@@ -58,10 +58,9 @@ public class SkybaneBot extends JavaPlugin {
 
         serviceManager.registerService(WhitelistManager.class);
 
-        if(Bukkit.getServer().getPluginManager().getPlugin("DiscordSRV") != null) {
-            inactivityManager = serviceManager.registerService(InactivityManager.class);
-            serviceManager.registerService(DiscordManager.class);
-        }
+        inactivityManager = serviceManager.registerService(InactivityManager.class);
+        serviceManager.registerService(DiscordManager.class);
+
         //
         serviceManager.startServices();
     }

--- a/src/main/java/com/github/atomishere/skybanebot/SkybaneBot.java
+++ b/src/main/java/com/github/atomishere/skybanebot/SkybaneBot.java
@@ -21,6 +21,7 @@ import com.github.atomishere.skybanebot.api.HypixelApiManager;
 import com.github.atomishere.skybanebot.api.MojangApiManager;
 import com.github.atomishere.skybanebot.cache.CacheManager;
 import com.github.atomishere.skybanebot.config.ConfigHandler;
+import com.github.atomishere.skybanebot.discord.DiscordChatLinker;
 import com.github.atomishere.skybanebot.discord.DiscordManager;
 import com.github.atomishere.skybanebot.inactivity.InactivityManager;
 import com.github.atomishere.skybanebot.service.ServiceManager;
@@ -61,6 +62,7 @@ public class SkybaneBot extends JavaPlugin {
 
         inactivityManager = serviceManager.registerService(InactivityManager.class);
         discordManager = serviceManager.registerService(DiscordManager.class);
+        serviceManager.registerService(DiscordChatLinker.class);
 
         //
         serviceManager.startServices();

--- a/src/main/java/com/github/atomishere/skybanebot/discord/DiscordChatLinker.java
+++ b/src/main/java/com/github/atomishere/skybanebot/discord/DiscordChatLinker.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2020 Archie O'Connor
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.atomishere.skybanebot.discord;
+
+import com.github.atomishere.skybanebot.SkybaneBot;
+import com.github.atomishere.skybanebot.config.ConfigurationValue;
+import com.github.atomishere.skybanebot.service.AbstractService;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.events.GenericEvent;
+import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.EventListener;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+import java.util.logging.Logger;
+
+public class DiscordChatLinker extends AbstractService implements Listener, EventListener {
+    private static final Logger logger = Logger.getLogger(DiscordChatLinker.class.getName());
+
+    @ConfigurationValue
+    private String guildId = "628246551881580585";
+    @ConfigurationValue
+    private String channelId = "746671552929726474";
+
+    private TextChannel chatChannel = null;
+
+    public DiscordChatLinker(SkybaneBot plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public void onStart() {
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            Guild guild;
+            try {
+                guild = plugin.getDiscordManager().getJda().awaitReady().getGuildById(guildId);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+                return;
+            }
+
+            if(guild == null) {
+                logger.warning("Could not find guild, not enabling chat linking.");
+                return;
+            }
+
+            TextChannel chatChannel = guild.getTextChannelById(channelId);
+            if(chatChannel == null) {
+                logger.warning("Could not find chat channel, not enabling chat linking.");
+                return;
+            }
+
+            this.chatChannel = chatChannel;
+            plugin.getDiscordManager().getJda().addEventListener(this);
+
+            chatChannel.sendMessage("Server has started!").complete();
+        });
+    }
+
+    @Override
+    public void onStop() {
+        chatChannel.sendMessage("Server is stopping!").complete();
+        chatChannel = null;
+    }
+
+    @EventHandler
+    public void onPlayerChat(AsyncPlayerChatEvent event) {
+        if(chatChannel != null && !event.getMessage().contains("@")) {
+            chatChannel.sendMessage(ChatColor.stripColor(event.getPlayer().getDisplayName() + " > " + event.getMessage())).submit();
+        }
+    }
+
+    @Override
+    public void onEvent(@NotNull GenericEvent event) {
+        if(event instanceof GuildMessageReceivedEvent) {
+            GuildMessageReceivedEvent messageEvent = (GuildMessageReceivedEvent) event;
+
+            if(!messageEvent.isWebhookMessage() && !messageEvent.getMember().getUser().isBot() && messageEvent.getChannel().equals(chatChannel)) {
+                Bukkit.getServer().broadcastMessage(ChatColor.GRAY + "[" + ChatColor.BLUE + "DISCORD" + ChatColor.GRAY + "] " + ChatColor.stripColor(messageEvent.getMember().getEffectiveName() + "> " + messageEvent.getMessage().getContentDisplay()));
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/atomishere/skybanebot/discord/DiscordManager.java
+++ b/src/main/java/com/github/atomishere/skybanebot/discord/DiscordManager.java
@@ -24,8 +24,6 @@ import com.github.atomishere.skybanebot.discord.commands.GetInactiveMembersComma
 import com.github.atomishere.skybanebot.discord.commands.RegisterInactivityCommand;
 import com.github.atomishere.skybanebot.service.AbstractService;
 import com.jagrosh.jdautilities.command.CommandClient;
-import com.jagrosh.jdautilities.command.CommandClientBuilder;
-import github.scarsz.discordsrv.DiscordSRV;
 
 public class DiscordManager extends AbstractService {
     private static final String OWNER_ID = "332423993132974081";
@@ -41,18 +39,10 @@ public class DiscordManager extends AbstractService {
 
     @Override
     public void onStart() {
-        GuildCache cache = plugin.getCacheManager().getCacheFromClass(GuildCache.class);
 
-        client = new CommandClientBuilder()
-                .setOwnerId(OWNER_ID)
-                .addCommands(new RegisterInactivityCommand(plugin, cache), new GetInactiveMembersCommand(requiredXp, plugin, cache))
-                .build();
-
-        DiscordSRV.getPlugin().getJda().addEventListener(client);
     }
 
     @Override
     public void onStop() {
-        DiscordSRV.getPlugin().getJda().removeEventListener(client);
     }
 }

--- a/src/main/java/com/github/atomishere/skybanebot/discord/DiscordManager.java
+++ b/src/main/java/com/github/atomishere/skybanebot/discord/DiscordManager.java
@@ -18,20 +18,44 @@
 package com.github.atomishere.skybanebot.discord;
 
 import com.github.atomishere.skybanebot.SkybaneBot;
-import com.github.atomishere.skybanebot.cache.guild.GuildCache;
 import com.github.atomishere.skybanebot.config.ConfigurationValue;
-import com.github.atomishere.skybanebot.discord.commands.GetInactiveMembersCommand;
-import com.github.atomishere.skybanebot.discord.commands.RegisterInactivityCommand;
 import com.github.atomishere.skybanebot.service.AbstractService;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.jagrosh.jdautilities.command.CommandClient;
+import com.neovisionaries.ws.client.DualStackMode;
+import com.neovisionaries.ws.client.WebSocketFactory;
+import lombok.Getter;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.events.ShutdownEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.requests.GatewayIntent;
+
+import javax.security.auth.login.LoginException;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.concurrent.*;
+import java.util.logging.Logger;
 
 public class DiscordManager extends AbstractService {
-    private static final String OWNER_ID = "332423993132974081";
+    private static final Logger logger =  Logger.getLogger(DiscordManager.class.getName());
 
-    private CommandClient client;
+    private static final String OWNER_ID = "332423993132974081";
+    private static final EnumSet<GatewayIntent> intents = EnumSet.of(
+            GatewayIntent.GUILD_MEMBERS,
+            GatewayIntent.GUILD_EMOJIS,
+            GatewayIntent.GUILD_MESSAGES
+    );
+
+    @Getter
+    private JDA jda;
+    private CommandClient commandClient;
 
     @ConfigurationValue
-    private int requiredXp = 25000;
+    private String botToken = "bot-token-here";
+
+    private ExecutorService callbackThreadPool;
 
     public DiscordManager(SkybaneBot plugin) {
         super(plugin);
@@ -39,10 +63,63 @@ public class DiscordManager extends AbstractService {
 
     @Override
     public void onStart() {
+        callbackThreadPool = new ForkJoinPool(Runtime.getRuntime().availableProcessors(), pool -> {
+            final ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
+            worker.setName("SkybaneBot - JDA Callback " + worker.getPoolIndex());
+            return worker;
+        }, null, true);
 
+        final ThreadFactory gatewayThreadFactory = new ThreadFactoryBuilder().setNameFormat("SkybaneBot - JDA Gateway").build();
+        final ScheduledExecutorService gatewayThreadPool = Executors.newSingleThreadScheduledExecutor(gatewayThreadFactory);
+
+        final ThreadFactory rateLimitThreadFactory = new ThreadFactoryBuilder().setNameFormat("DiscordSRV - JDA Rate Limit").build();
+        final ScheduledExecutorService rateLimitThreadPool = new ScheduledThreadPoolExecutor(5, rateLimitThreadFactory);
+
+        try {
+            jda = JDABuilder.create(Sets.immutableEnumSet(intents))
+                    .setCallbackPool(callbackThreadPool, false)
+                    .setGatewayPool(gatewayThreadPool, true)
+                    .setRateLimitPool(rateLimitThreadPool, true)
+                    .setWebsocketFactory(new WebSocketFactory().setDualStackMode(DualStackMode.IPV4_ONLY))
+                    .setAutoReconnect(true)
+                    .setBulkDeleteSplittingEnabled(false)
+                    .setToken(botToken)
+                    .setContextEnabled(false)
+                    .build().awaitReady();
+        } catch (LoginException | InterruptedException ignored) {
+            // already logged by JDA
+        }
     }
 
     @Override
     public void onStop() {
+        final ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("SkybaneBot - Shutdown").build();
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            executor.invokeAll(Collections.singletonList(() -> {
+                jda.getEventManager().getRegisteredListeners().forEach(l -> jda.getEventManager().unregister(l));
+
+                CompletableFuture<Void> shutdownTask = new CompletableFuture<>();
+                jda.addEventListener(new ListenerAdapter() {
+                    @Override
+                    public void onShutdown(ShutdownEvent event) {
+                        shutdownTask.complete(null);
+                    }
+                });
+                jda.shutdownNow();
+                jda = null;
+                try {
+                    shutdownTask.get(5, TimeUnit.SECONDS);
+                } catch(TimeoutException e) {
+                    logger.warning("JDA took too long to shut down!");
+                }
+
+                callbackThreadPool.shutdownNow();
+                return null;
+            }));
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        executor.shutdownNow();
     }
 }

--- a/src/main/java/com/github/atomishere/skybanebot/discord/commands/GetInactiveMembersCommand.java
+++ b/src/main/java/com/github/atomishere/skybanebot/discord/commands/GetInactiveMembersCommand.java
@@ -29,11 +29,11 @@ public class GetInactiveMembersCommand extends Command {
     private final SkybaneBot plugin;
     private final GuildCache cache;
 
-    public GetInactiveMembersCommand(int requiredXp, SkybaneBot plugin, GuildCache cache) {
+    public GetInactiveMembersCommand(int requiredXp, SkybaneBot plugin) {
         this.requiredXp = requiredXp;
 
         this.plugin = plugin;
-        this.cache = cache;
+        this.cache = plugin.getCacheManager().getCacheFromClass(GuildCache.class);
 
         this.botPermissions = new Permission[]{Permission.MESSAGE_MANAGE};
         this.name = "getInactiveMembers";

--- a/src/main/java/com/github/atomishere/skybanebot/discord/commands/GetInactiveMembersCommand.java
+++ b/src/main/java/com/github/atomishere/skybanebot/discord/commands/GetInactiveMembersCommand.java
@@ -48,7 +48,7 @@ public class GetInactiveMembersCommand extends Command {
 
         cache.getValues()
                 .stream()
-                .filter(g -> g.getWeeklyXp() >= requiredXp)
+                .filter(g -> g.getWeeklyXp() <= requiredXp)
                 .filter(g -> !plugin.getInactivityManager().isInactive(g.getUsername()))
                 .forEach(g -> messageBuilder.append("\n    ").append(g.getUsername()).append(": ").append(g.getWeeklyXp()));
 

--- a/src/main/java/com/github/atomishere/skybanebot/discord/commands/RegisterInactivityCommand.java
+++ b/src/main/java/com/github/atomishere/skybanebot/discord/commands/RegisterInactivityCommand.java
@@ -46,6 +46,7 @@ public class RegisterInactivityCommand extends Command {
         String[] args = event.getArgs().split(" ");
         if(args.length != 2) {
             event.reply(USAGE);
+            return;
         }
 
         String username = args[0];

--- a/src/main/java/com/github/atomishere/skybanebot/discord/commands/RegisterInactivityCommand.java
+++ b/src/main/java/com/github/atomishere/skybanebot/discord/commands/RegisterInactivityCommand.java
@@ -32,9 +32,9 @@ public class RegisterInactivityCommand extends Command {
     private final SkybaneBot plugin;
     private final GuildCache cache;
 
-    public RegisterInactivityCommand(SkybaneBot plugin, GuildCache cache) {
+    public RegisterInactivityCommand(SkybaneBot plugin) {
         this.plugin = plugin;
-        this.cache = cache;
+        this.cache = plugin.getCacheManager().getCacheFromClass(GuildCache.class);
 
         this.name = "registerInactivity";
         this.help = "Register for inactivity";

--- a/src/main/java/com/github/atomishere/skybanebot/inactivity/InactivityManager.java
+++ b/src/main/java/com/github/atomishere/skybanebot/inactivity/InactivityManager.java
@@ -72,7 +72,7 @@ public class InactivityManager extends AbstractService {
         for(Inactive inactive : inactivePeople) {
             ConfigurationSection section = config.getConfig().createSection(inactive.getUsername());
             section.set("username", inactive.getUsername());
-            section.set("endData", dateFormatter.format(inactive.getEndDate()));
+            section.set("endDate", dateFormatter.format(inactive.getEndDate()));
         }
     }
 

--- a/src/main/java/com/github/atomishere/skybanebot/service/ServiceManager.java
+++ b/src/main/java/com/github/atomishere/skybanebot/service/ServiceManager.java
@@ -25,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -50,6 +51,7 @@ public class ServiceManager {
             return;
         }
 
+        Collections.reverse(services);
         services.forEach(IService::stop);
         started = false;
     }
@@ -90,7 +92,7 @@ public class ServiceManager {
     @SuppressWarnings("unchecked")
     public <S extends IService> S getServiceFromClass(Class<S> serviceClass) {
         return (S) services.stream()
-                .filter(s -> serviceClass.isInstance(serviceClass))
+                .filter(serviceClass::isInstance)
                 .findFirst()
                 .orElseThrow(() -> new ServiceNotFoundException(serviceClass));
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,5 +2,3 @@ name: SkybaneBot
 main: com.github.atomishere.skybanebot.SkybaneBot
 version: 1.0.0
 author: AtomIsHere
-
-softdepend: [DiscordSRV]


### PR DESCRIPTION
This is meant to add our own implementation of JDA instead of relying on JDA. This has many purposes one of the main one is to be able to use jda-utilites, which requires a non relocated JDA, where in DiscordSRV JDA is relocated. Another thing is to cut down on bloat, DiscordSRV has a lot of unneeded features so we can just remove it and cut down on the bloat. While this may need some more upkeep, all in all this change is a net positive